### PR TITLE
Add deprecation warnings for SQL execution features

### DIFF
--- a/batis.asd
+++ b/batis.asd
@@ -26,10 +26,10 @@
   :components ((:module "src"
                 :components
                 ((:file "batis" :depends-on ("macro" "sqlparser" "sql" "datasource"))
-                 (:file "macro" :depends-on ("sql"))
+                 (:file "macro")
                  (:file "sqlparser")
                  (:file "dbi")
-                 (:file "sql" :depends-on ("sqlparser" "datasource" "dbi"))
+                 (:file "sql" :depends-on ("sqlparser" "datasource" "dbi" "macro"))
                  (:file "datasource"))))
   :description "SQL Mapping Framework for Common Lisp"
   :long-description

--- a/src/batis.lisp
+++ b/src/batis.lisp
@@ -14,10 +14,12 @@
   (:import-from :batis.sqlparser
                 :parse)
   (:import-from :batis.sql
+                :gen-sql-and-params
                 :select-one
                 :select-list
                 :update-one)
   (:import-from :batis.macro
+                :<batis-sql>
                 :defsql
                 :sql-where
                 :sql-set
@@ -26,7 +28,17 @@
                 :update)
   (:import-from :batis.dbi
                 :do-sql)
-  (:export :<sql-session>
+  (:export :<batis-sql>
+           :gen-sql-and-params
+           :defsql
+           :sql-where
+           :sql-set
+           :sql-cond
+           :select
+           :update
+
+           ;; deprecated symbols
+           :<sql-session>
            :connection
            :create-sql-session
            :with-transaction
@@ -37,12 +49,6 @@
            :select-one
            :select-list
            :update-one
-           :defsql
-           :sql-where
-           :sql-set
-           :sql-cond
-           :select
-           :update
            :do-sql))
 (in-package :batis)
 

--- a/src/batis.lisp
+++ b/src/batis.lisp
@@ -36,6 +36,7 @@
            :sql-cond
            :select
            :update
+           :parse
 
            ;; deprecated symbols
            :<sql-session>
@@ -45,7 +46,6 @@
            :commit
            :rollback
            :close-sql-session
-           :parse
            :select-one
            :select-list
            :update-one

--- a/src/datasource.lisp
+++ b/src/datasource.lisp
@@ -11,7 +11,8 @@
   ((connection :type dbi.driver::<dbi-connection>
                :initarg :connection
                :accessor connection
-               :initform (error "missing initarg"))))
+               :initform (error "missing initarg")))
+  (:documentation "DEPRECATED: This class is deprecated and will be removed in a future version."))
 
 (defclass <sql-session-dbi> (<sql-session>)
   ())
@@ -25,6 +26,7 @@
 
 @export
 (defmethod create-sql-session ((conn dbi.driver::<dbi-connection>) &key &allow-other-keys)
+  (warn "CREATE-SQL-SESSION is deprecated and will be removed in a future version.")
   (prog1
       (make-instance '<sql-session-dbi>
                      :connection conn)))
@@ -32,6 +34,7 @@
 
 @export
 (defmethod create-sql-session ((connection-pool dbi-cp.connectionpool:<dbi-connection-pool>) &key &allow-other-keys)
+  (warn "CREATE-SQL-SESSION is deprecated and will be removed in a future version.")
   (let* ((connection-proxy (dbi-cp:get-connection connection-pool))
          (conn (dbi-cp.proxy:dbi-connection connection-proxy)))
     (prog1
@@ -43,6 +46,7 @@
 @export
 (defmethod create-sql-session (driver-name &rest params &key database-name &allow-other-keys)
   (declare (ignore database-name))
+  (warn "CREATE-SQL-SESSION is deprecated and will be removed in a future version.")
   (let ((conn (apply #'dbi:connect driver-name params)))
     (prog1
         (make-instance '<sql-session-dbi>
@@ -50,6 +54,7 @@
 
 @export
 (defmacro with-transaction (session &body body)
+  (warn "WITH-TRANSACTION is deprecated and will be removed in a future version.")
   (let ((conn-var (gensym "CONN-VAR")))
     `(let ((,conn-var (batis.datasource::connection ,session)))
        (dbi:with-transaction ,conn-var
@@ -57,27 +62,33 @@
 
 @export
 (defmethod commit ((session <sql-session-dbi>))
+  (warn "COMMIT is deprecated and will be removed in a future version.")
   (dbi:commit (connection session)))
 
 @export
 (defmethod commit ((session <sql-session-dbi-cp>))
+  (warn "COMMIT is deprecated and will be removed in a future version.")
   (dbi-cp:commit (proxy session)))
 
 @export
 (defmethod rollback ((session <sql-session-dbi>))
+  (warn "ROLLBACK is deprecated and will be removed in a future version.")
   (dbi:rollback (connection session)))
 
 @export
 (defmethod rollback ((session <sql-session-dbi-cp>))
+  (warn "ROLLBACK is deprecated and will be removed in a future version.")
   (dbi-cp:rollback (proxy session)))
 
 
 @export
 (defmethod close-sql-session ((session <sql-session-dbi>))
+  (warn "CLOSE-SQL-SESSION is deprecated and will be removed in a future version.")
   (dbi:disconnect (connection session)))
 
 @export
 (defmethod close-sql-session ((session <sql-session-dbi-cp>))
+  (warn "CLOSE-SQL-SESSION is deprecated and will be removed in a future version.")
   (dbi-cp:disconnect (proxy session)))
 
 

--- a/src/dbi.lisp
+++ b/src/dbi.lisp
@@ -9,6 +9,7 @@
 
 @export
 (defmethod do-sql ((session <sql-session>) sql &optional params)
+  (warn "DO-SQL is deprecated and will be removed in a future version.")
   (let ((conn (batis.datasource::connection session)))
     (dbi:do-sql conn sql params)))
 

--- a/src/macro.lisp
+++ b/src/macro.lisp
@@ -7,14 +7,23 @@
 (cl-syntax:use-syntax :annot)
 
 @export
+(defclass <batis-sql> ()
+  ((gen-sql-fn :type function
+               :initarg :gen-sql-fn
+               :initform (error "missing gen-sql-fn"))
+   (sql-type :type keyword
+             :initarg :sql-type)))
+
+@export
 (defmacro defsql (sql-name args &key sql-body sql-type &allow-other-keys)
   "define sql name and its args"
   (declare (ignore sql-type))
   `(defparameter
        ,sql-name
-     (lambda (&key ,@args &allow-other-keys)
-       (declare (ignore ,@args))
-       ,sql-body)))
+     (make-instance '<batis-sql> :gen-sql-fn (lambda (&key ,@args &allow-other-keys)
+                                               (declare (ignore ,@args))
+                                               ,sql-body)
+                                 :sql-type ,sql-type)))
 
 @export
 (defmacro sql-cond (test-form sql-body)

--- a/src/sql.lisp
+++ b/src/sql.lisp
@@ -19,15 +19,18 @@
 
 @export
 (defmethod select-one ((session <sql-session>) sql-name &rest params &key &allow-other-keys)
+  (warn "SELECT-ONE is deprecated and will be removed in a future version.")
   (car (apply #'select-list session sql-name params)))
 
 @export
 (defmethod select-list ((session <sql-session>) sql-name &rest params &key &allow-other-keys)
+  (warn "SELECT-LIST is deprecated and will be removed in a future version.")
   (multiple-value-bind (sql params) (gen-sql-and-params sql-name params)
     (sql-execute session sql params)))
 
 @export
 (defmethod update-one ((session <sql-session>) sql-name &rest params &key &allow-other-keys)
+  (warn "UPDATE-ONE is deprecated and will be removed in a future version.")
   (multiple-value-bind (sql params) (gen-sql-and-params sql-name params)
     (sql-execute session sql params)))
 

--- a/src/sql.lisp
+++ b/src/sql.lisp
@@ -9,7 +9,9 @@
                 :proxy
                 :<sql-session-dbi-cp>)
   (:import-from :batis.sqlparser
-                :parse))
+                :parse)
+  (:import-from :batis.macro
+                :<batis-sql>))
 (in-package :batis.sql)
 
 (cl-syntax:use-syntax :annot)
@@ -21,12 +23,12 @@
 
 @export
 (defmethod select-list ((session <sql-session>) sql-name &rest params &key &allow-other-keys)
-  (multiple-value-bind (sql params) (gen-sql-params sql-name params)
+  (multiple-value-bind (sql params) (gen-sql-and-params sql-name params)
     (sql-execute session sql params)))
 
 @export
 (defmethod update-one ((session <sql-session>) sql-name &rest params &key &allow-other-keys)
-  (multiple-value-bind (sql params) (gen-sql-params sql-name params)
+  (multiple-value-bind (sql params) (gen-sql-and-params sql-name params)
     (sql-execute session sql params)))
 
 (defmethod sql-execute ((session <sql-session-dbi>) sql params)
@@ -44,9 +46,11 @@
     (dbi-cp:fetch-all result)))
 
 
-(defun gen-sql-params (sql-name params)
+@export
+(defmethod gen-sql-and-params ((sql-name <batis-sql>) params)
   "generate parameterized SQL and its parameters"
-  (let* ((sql (apply sql-name params))
+  (let* ((sql-fn (slot-value sql-name 'batis.macro::gen-sql-fn))
+         (sql (apply sql-fn params))
          (parsed-sql (parse sql))
          (params (create-params (getf parsed-sql :args) params)))
     (values (getf parsed-sql :sql) params)))

--- a/src/sqlparser.lisp
+++ b/src/sqlparser.lisp
@@ -57,7 +57,7 @@
       (push (list start pos)
             params)
       (let ((c (char sql pos)))
-        (cond ((find c "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_0123456789")
+        (cond ((find c "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_-0123456789")
                (lex-colon sql (1+ pos) len params start))
               ((or (char= c #\Space)
                    (char= c #\Tab)

--- a/t/macro.lisp
+++ b/t/macro.lisp
@@ -3,7 +3,9 @@
   (:use :cl
         :cl-annot
         :batis.macro
-        :rove))
+        :rove)
+  (:import-from :batis.sql
+                :gen-sql-and-params))
 (in-package :batis-test.macro)
 
 (cl-syntax:use-syntax :annot)
@@ -21,47 +23,60 @@
 @select (" select * from product "
          (sql-where
           " valid_flag = '1' "
-          (sql-cond (not (null product_name))
-                    " and product_name like :product_name ")))
-(defsql fetch-product (product_name))
+          (sql-cond (not (null product-name))
+                    " and product_name like :product-name ")))
+(defsql fetch-product (product-name))
 
 (deftest select-single-param
-  (ok (string= " select * from product  where   valid_flag = '1' "
-               (funcall fetch-product)))
-  (ok (string= " select * from product  where   valid_flag = '1'   and product_name like :product_name "
-               (funcall fetch-product :product_name "CommonLisp"))))
+  (multiple-value-bind (sql params)
+      (gen-sql-and-params fetch-product '())
+    (ok (string= " select * from product  where   valid_flag = '1' " sql))
+    (ok (equal '() params)))
 
+  (multiple-value-bind (sql params)
+      (gen-sql-and-params fetch-product '(:product-name "CommonLisp"))
+    (ok (string= " select * from product  where   valid_flag = '1'   and product_name like ?             " sql))
+    (ok (equal '("CommonLisp") params))))
 
 ;; ----------------------------------------
 ;; SELECT param 3
 ;; ----------------------------------------
 @select (" select * from product "
          (sql-where
-          (sql-cond (not (null valid_flag))
-                    " valid_flag = :valid_flag ")
-          (sql-cond (not (null product_name))
-                    " and product_name like :product_name ")
-          (sql-cond (and (not (null product_price_low))
-                         (not (null product_price_high)))
-                    " and product_price between :product_price_low and :product_price_high ")))
-(defsql fetch-product2 (valid_flag product_name product_price_low product_price_high))
+          (sql-cond (not (null valid-flag))
+                    " valid_flag = :valid-flag ")
+          (sql-cond (not (null product-name))
+                    " and product_name like :product-name ")
+          (sql-cond (and (not (null product-price-low))
+                         (not (null product-price-high)))
+                    " and product_price between :product-price-low and :product-price-high ")))
+(defsql fetch-product2 (valid-flag product-name product-price-low product-price-high))
 
 (deftest select-multi-param
-  (ok (string= " select * from product "
-               (funcall fetch-product2)))
-  (ok (string= " select * from product  where   product_name like :product_name "
-               (funcall fetch-product2 :product_name "CommonLisp")))
-  (ok (string= " select * from product  where   valid_flag = :valid_flag   and product_price between :product_price_low and :product_price_high "
-               (funcall fetch-product2
-                        :valid_flag '1'
-                        :product_price_low 1000
-                        :product_price_high 2000)))
-  (ok (string= " select * from product  where   valid_flag = :valid_flag   and product_name like :product_name   and product_price between :product_price_low and :product_price_high "
-               (funcall fetch-product2
-                        :valid_flag '1'
-                        :product_price_low 1000
-                        :product_price_high 2000
-                        :product_name "CommonLisp"))))
+  (multiple-value-bind (sql params)
+      (gen-sql-and-params fetch-product2 '())
+    (ok (string= " select * from product " sql))
+    (ok (equal '() params)))
+
+  (multiple-value-bind (sql params)
+      (gen-sql-and-params fetch-product2 '(:product-name "CommonLisp"))
+    (ok (string= " select * from product  where   product_name like ?             " sql))
+    (ok (equal '("CommonLisp") params)))
+
+  (multiple-value-bind (sql params)
+      (gen-sql-and-params fetch-product2 '(:valid-flag 1
+                                           :product-price-low 1000
+                                           :product-price-high 2000))
+    (ok (string= " select * from product  where   valid_flag = ?             and product_price between ?                  and ?                   " sql))
+    (ok (equal '(1 1000 2000) params)))
+
+  (multiple-value-bind (sql params)
+      (gen-sql-and-params fetch-product2 '(:valid-flag 1
+                                           :product-price-low 1000
+                                           :product-price-high 2000
+                                           :product-name "CommonLisp"))
+    (ok (string= " select * from product  where   valid_flag = ?             and product_name like ?               and product_price between ?                  and ?                   " sql))
+    (ok (equal '(1 "CommonLisp" 1000 2000) params))))
 
 
 ;; ----------------------------------------
@@ -70,26 +85,34 @@
 
 @update (" update product "
          (sql-set
-          " update_date = :update_date, "
-          (sql-cond (not (null product_name))
-                    " product_name = :product_name, ")
-          (sql-cond (not (null product_price))
-                    " product_price = :product_price "))
+          " update_date = :update-date, "
+          (sql-cond (not (null product-name))
+                    " product_name = :product-name, ")
+          (sql-cond (not (null product-price))
+                    " product_price = :product-price "))
          (sql-where
-          "product_id = :product_id "))
-(defsql update-product (product_name product_price product_id))
+          "product_id = :product-id "))
+(defsql update-product (update-date product-name product-price product-id))
 
 (deftest update-multi-param
-  (ok (string= " update product  set  update_date = :update_date  where  product_id = :product_id "
-               (funcall update-product
-                        :product_id 1)))
-  (ok (string= " update product  set  update_date = :update_date,  product_name = :product_name  where  product_id = :product_id "
-               (funcall update-product
-                        :product_id 1
-                        :product_name "CLHS")))
-  (ok (string= " update product  set  update_date = :update_date,  product_name = :product_name,  product_price = :product_price  where  product_id = :product_id "
-               (funcall update-product
-                        :product_id 1
-                        :product_price 3000
-                        :product_name "CLHS"))))
+  (multiple-value-bind (sql params)
+      (gen-sql-and-params update-product '(:update-date "2025-01-01"
+                                           :product-id 1))
+    (ok (string= " update product  set  update_date = ?             where  product_id = ?           " sql))
+    (ok (equal '("2025-01-01" 1) params)))
+
+  (multiple-value-bind (sql params)
+      (gen-sql-and-params update-product '(:update-date "2025-01-01"
+                                           :product-id 1
+                                           :product-name "CLHS"))
+    (ok (string= " update product  set  update_date = ?           ,  product_name = ?              where  product_id = ?           " sql))
+    (ok (equal '("2025-01-01" "CLHS" 1) params)))
+
+  (multiple-value-bind (sql params)
+      (gen-sql-and-params update-product '(:update-date "2025-01-01"
+                                           :product-id 1
+                                           :product-price 3000
+                                           :product-name "CLHS"))
+    (ok (string= " update product  set  update_date = ?           ,  product_name = ?            ,  product_price = ?               where  product_id = ?           " sql))
+    (ok (equal '("2025-01-01" "CLHS" 3000 1) params))))
 


### PR DESCRIPTION
## Overview

This PR marks SQL execution and session management features as deprecated, focusing cl-batis on its core responsibility: SQL definition and generation for prepared statements.

## Changes

### 1. Added deprecation warnings

Added runtime warnings to the following deprecated functions and methods:

**Session Management (src/datasource.lisp):**
- `create-sql-session` - All three method specializations
- `with-transaction` - Macro for transaction management
- `commit` - Both `<sql-session-dbi>` and `<sql-session-dbi-cp>` methods
- `rollback` - Both `<sql-session-dbi>` and `<sql-session-dbi-cp>` methods
- `close-sql-session` - Both `<sql-session-dbi>` and `<sql-session-dbi-cp>` methods
- `<sql-session>` - Added deprecation notice to class documentation


**SQL Execution (src/sql.lisp):**
- `select-one`
- `select-list`
- `update-one`

**DBI Operations (src/dbi.lisp):**
- `do-sql`

When these functions are called, users will see a warning message like:
```
WARNING: CREATE-SQL-SESSION is deprecated and will be removed in a future version.
```

### 2. Updated README.markdown

**Added:**
- **Overview section** explaining that cl-batis is a library for generating prepared statement queries and parameters
- **Generate SQL and Parameters section** demonstrating `gen-sql-and-params` usage with examples
- Reorganized content to emphasize SQL definition (`select`, `update`, `defsql`) and generation

**Moved:**
- All session management and SQL execution documentation moved to a new **Deprecated Features** section at the end of the README
- Clear notice that these features will be removed in a future version

## Motivation

This change aligns cl-batis with a clearer separation of concerns:
- **cl-batis**: SQL definition and prepared statement generation
- **Other libraries** (like CL-DBI): Query execution and connection management

By deprecating execution features, we:
1. Reduce the library's scope to a single, well-defined responsibility
2. Allow users to choose their preferred execution libraries
3. Make the library easier to maintain and test
4. Provide clear migration path through deprecation warnings

## Breaking Changes

**None in this PR** - this is a soft deprecation. All deprecated features continue to work but emit warnings. Actual removal will occur in a future major version.

## Migration Guide

Users should:
1. Continue using `defsql`, `select`, `update`, `sql-where`, `sql-set`, and `sql-cond` for SQL definition
2. Use `gen-sql-and-params` to generate SQL and parameters
3. Use their preferred database library (CL-DBI, etc.) for execution instead of `select-one`, `select-list`, `update-one`

Example migration:

**Before:**
```common-lisp
(select-one *session* search-product :id 1)
```

**After:**
```common-lisp
(multiple-value-bind (sql params)
    (gen-sql-and-params search-product :id 1)
  (car (dbi:fetch-all (dbi:execute (dbi:prepare *connection* sql) params))))
```













