### PR TITLE
Support PostgreSQL Type Cast Syntax (::)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM fukamachi/sbcl
+FROM fukamachi/sbcl:2.5.10
 
 RUN apt-get update && apt-get install -y \
   default-libmysqlclient-dev \

--- a/t/macro.lisp
+++ b/t/macro.lisp
@@ -35,7 +35,7 @@
 
   (multiple-value-bind (sql params)
       (gen-sql-and-params fetch-product '(:product-name "CommonLisp"))
-    (ok (string= " select * from product  where   valid_flag = '1'   and product_name like ?             " sql))
+    (ok (string= " select * from product  where   valid_flag = '1'   and product_name like             ? " sql))
     (ok (equal '("CommonLisp") params))))
 
 ;; ----------------------------------------
@@ -60,14 +60,14 @@
 
   (multiple-value-bind (sql params)
       (gen-sql-and-params fetch-product2 '(:product-name "CommonLisp"))
-    (ok (string= " select * from product  where   product_name like ?             " sql))
+    (ok (string= " select * from product  where   product_name like             ? " sql))
     (ok (equal '("CommonLisp") params)))
 
   (multiple-value-bind (sql params)
       (gen-sql-and-params fetch-product2 '(:valid-flag 1
                                            :product-price-low 1000
                                            :product-price-high 2000))
-    (ok (string= " select * from product  where   valid_flag = ?             and product_price between ?                  and ?                   " sql))
+    (ok (string= " select * from product  where   valid_flag =           ?   and product_price between                  ? and                   ? " sql))
     (ok (equal '(1 1000 2000) params)))
 
   (multiple-value-bind (sql params)
@@ -75,7 +75,7 @@
                                            :product-price-low 1000
                                            :product-price-high 2000
                                            :product-name "CommonLisp"))
-    (ok (string= " select * from product  where   valid_flag = ?             and product_name like ?               and product_price between ?                  and ?                   " sql))
+    (ok (string= " select * from product  where   valid_flag =           ?   and product_name like             ?   and product_price between                  ? and                   ? " sql))
     (ok (equal '(1 "CommonLisp" 1000 2000) params))))
 
 
@@ -98,14 +98,14 @@
   (multiple-value-bind (sql params)
       (gen-sql-and-params update-product '(:update-date "2025-01-01"
                                            :product-id 1))
-    (ok (string= " update product  set  update_date = ?             where  product_id = ?           " sql))
+    (ok (string= " update product  set  update_date =            ?  where  product_id =           ? " sql))
     (ok (equal '("2025-01-01" 1) params)))
 
   (multiple-value-bind (sql params)
       (gen-sql-and-params update-product '(:update-date "2025-01-01"
                                            :product-id 1
                                            :product-name "CLHS"))
-    (ok (string= " update product  set  update_date = ?           ,  product_name = ?              where  product_id = ?           " sql))
+    (ok (string= " update product  set  update_date =            ?,  product_name =             ?  where  product_id =           ? " sql))
     (ok (equal '("2025-01-01" "CLHS" 1) params)))
 
   (multiple-value-bind (sql params)
@@ -113,6 +113,19 @@
                                            :product-id 1
                                            :product-price 3000
                                            :product-name "CLHS"))
-    (ok (string= " update product  set  update_date = ?           ,  product_name = ?            ,  product_price = ?               where  product_id = ?           " sql))
+    (ok (string= " update product  set  update_date =            ?,  product_name =             ?,  product_price =              ?  where  product_id =           ? " sql))
     (ok (equal '("2025-01-01" "CLHS" 3000 1) params))))
+
+
+;; ----------------------------------------
+;; PostgreSQL :: CAST
+;; ----------------------------------------
+@select (" select * from product where product_id = :product-id::INTEGER ")
+(defsql fetch-product-with-cast (product-id))
+
+(deftest select-with-postgresql-cast
+  (multiple-value-bind (sql params)
+      (gen-sql-and-params fetch-product-with-cast '(:product-id "123"))
+    (ok (string= " select * from product where product_id =           ?::INTEGER " sql))
+    (ok (equal '("123") params))))
 

--- a/t/sqlparser.lisp
+++ b/t/sqlparser.lisp
@@ -18,7 +18,7 @@
              (parse "select column from table")))
 
   ; named parameter
-  (ok (equal '(:SQL "select column from table where id = ?  "
+  (ok (equal '(:SQL "select column from table where id =   ?"
                :ARGS (:ID))
              (parse "select column from table where id = :id")))
 
@@ -28,12 +28,12 @@
              (parse "update table set column = ':column'")))
 
   ; update SQL
-  (ok (equal '(:SQL "select column from table where valid_flag = ?           and id = ?  "
+  (ok (equal '(:SQL "select column from table where valid_flag =           ? and id =   ?"
                :ARGS (:VALID_FLAG :ID))
              (parse "select column from table where valid_flag = :valid_flag and id = :id")))
 
   ; insert SQL
-  (ok (equal '(:SQL "insert into table (id, column, valid_flag) values (?  , ?      , ?          )"
+  (ok (equal '(:SQL "insert into table (id, column, valid_flag) values (  ?,       ?,           ?)"
                :ARGS (:ID :COLUMN :VALID_FLAG))
              (parse "insert into table (id, column, valid_flag) values (:id, :column, :valid_flag)")))
 
@@ -48,23 +48,23 @@
                   m_team,
                   m_group
                 where
-                  m_user.user_id = ?       
+                  m_user.user_id =        ?
                 and
                   m_team.team_id = m_user.team_id
                 and
                   m_group.group_id = m_team.team_id
                 and
-                  m_user.valid_start_date <= ?          
+                  m_user.valid_start_date <=           ?
                 and
-                  m_user.valid_end_date > ?        
+                  m_user.valid_end_date >         ?
                 and
-                  m_team.valid_start_date <= ?          
+                  m_team.valid_start_date <=           ?
                 and
-                  m_team.valid_end_date > ?        
+                  m_team.valid_end_date >         ?
                 and
-                  m_group.valid_start_date <= ?          
+                  m_group.valid_start_date <=           ?
                 and
-                  m_group.valid_end_date > ?        "
+                  m_group.valid_end_date >         ?"
           :ARGS (:USER_ID :START_DATE :END_DATE :START_DATE :END_DATE :START_DATE :END_DATE))
         (parse "select
                   m_group.group_name,


### PR DESCRIPTION
## Summary

This PR adds support for PostgreSQL's type cast syntax (`::`) in SQL parameter handling. Previously, using `::` after a named parameter (e.g., `:param::INTEGER`) would cause parsing issues. Now the parser correctly ha.

## Changes

### SQL Parser Improvements

1. **Added `lex-param` mode**: Introduced a new lexer state to properly distinguish between parameter names and the `::` type cast operator.

2. **Refactored character validation**: Replaced hardcoded character string checks with `cl-ppcre` regex for cleaner, more maintainable code.

3. **Updated parameter replacement logic**: Modified the `parse` function to place `?` at the end of the parameter name instead of the beginning, allowing `::` to remain in the SQL output.

### Behavior Changes

- **Before**: `:product-id::INTEGER` → `?          :?        ` (broken)
- **After**: `:product-id::INTEGER` → `           ?::INTEGER` (correct)

The `?` placeholder now appears at the end of the parameter name position, preserving any following `::` type cast syntax.

## Implementation Details

### Parser State Machine

The parser now uses three distinct states when processing parameters:

1. **`lex-normal`**: Default state, detects `:` and transitions to `lex-colon`
2. **`lex-colon`**: After encountering `:`, checks the next character:
   - If `:` → returns to `lex-normal` (handles `::` escape)
   - If alphanumeric → transitions to `lex-param`
   - Otherwise → returns to `lex-normal`
3. **`lex-param`**: Reading parameter name, accumulates valid characters until:
   - Encounters `:` → registers parameter and returns to `lex-normal`
   - Encounters whitespace/quote/other → registers parameter and continues

### Character Validation

Introduced `param-char-p` function using `cl-ppcre`:

```lisp
(defun param-char-p (c)
  "Check if character is valid for parameter name"
  (scan "^[a-zA-Z0-9_-]$" (string c)))
```

This replaces multiple instances of the hardcoded character string `"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_-0123456789"`.

## Testing

- All existing tests updated to reflect new parameter replacement behavior
- New test added for PostgreSQL type cast syntax: `select-with-postgresql-cast`
- All 9 test suites pass successfully

## Example Usage

```lisp
@select ("select * from product where product_id = :product-id::INTEGER")
(defsql fetch-product-with-cast (product-id))
```

Generates:
```sql
SQL: "select * from product where product_id =           ?::INTEGER"
Args: (:PRODUCT-ID)
```

## Breaking Changes

None. This is a bug fix that enables previously broken syntax to work correctly.